### PR TITLE
Fixing interactions between Faulty Coupler and Stellarator

### DIFF
--- a/src/main/java/aspiration/actions/FuseValidOrbsAction.java
+++ b/src/main/java/aspiration/actions/FuseValidOrbsAction.java
@@ -33,31 +33,45 @@ public class FuseValidOrbsAction extends AbstractGameAction {
 
     @Override
     public void update() {
-        AbstractDungeon.actionManager.addToTop(new ChannelAction(new AmalgamateOrb(AbstractDungeon.player.orbs))); //this triggers last
-        //AbstractDungeon.actionManager.addToTop(new WaitAction(10.0f));
-        ArrayList<AbstractOrb> orbsToRemove = OrbUtilityMethods.getOrbList(true);
-        AbstractDungeon.player.orbs.forEach(o -> {
-            for(AbstractOrb orb : orbsToRemove) {
-                if (orb.getClass().isInstance(o)) {
-                    //System.out.println("Crash bas?");
-                    AbstractDungeon.actionManager.addToTop(new RemoveSpecificOrbAction(o));
-                    //AbstractDungeon.actionManager.addToTop(new VFXAction(new SmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY)));
-                    try {
-                        if(orb.ID.equals(Frost.ORB_ID) || orb.ID.equals(Plasma.ORB_ID) || (Aspiration.hasConspire && orb.ID.equals(Water.ORB_ID)) || (Aspiration.hasReplay && (orb.ID.equals(ManaSparkOrb.ORB_ID) || orb.ID.equals(CrystalOrb.ORB_ID)))) {
-                            AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration));
-                        } else if(orb.ID.equals(Dark.ORB_ID)) {
-                            AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration, Color.PURPLE));
-                        } else if(orb.ID.equals(Lightning.ORB_ID) || (Aspiration.hasReplay && orb.ID.equals(ReplayLightOrb.ORB_ID))) {
-                            AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration, Color.YELLOW));
-                        } else if (Aspiration.hasReplay && orb.ID.equals(HellFireOrb.ORB_ID)) {
-                            AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration, Color.RED));
-                        }
-                    } catch (Exception e) {
-                        Aspiration.logger.info(e);
-                    }
+        ArrayList<AbstractOrb> acceptableOrbs = OrbUtilityMethods.getOrbList(true);
+        boolean hasValidOrb = false;
+
+        for (AbstractOrb orb : AbstractDungeon.player.orbs) {
+            for (AbstractOrb aorb : acceptableOrbs) {
+                if (aorb.getClass().isInstance(orb)) {
+                    hasValidOrb = true;
                 }
             }
-        });
+        }
+
+        if (hasValidOrb)
+        {
+            AbstractDungeon.actionManager.addToTop(new ChannelAction(new AmalgamateOrb(AbstractDungeon.player.orbs))); //this triggers last
+            //AbstractDungeon.actionManager.addToTop(new WaitAction(10.0f));
+            ArrayList<AbstractOrb> orbsToRemove = OrbUtilityMethods.getOrbList(true);
+            AbstractDungeon.player.orbs.forEach(o -> {
+                for(AbstractOrb orb : orbsToRemove) {
+                    if (orb.getClass().isInstance(o)) {
+                        //System.out.println("Crash bas?");
+                        AbstractDungeon.actionManager.addToTop(new RemoveSpecificOrbAction(o));
+                        //AbstractDungeon.actionManager.addToTop(new VFXAction(new SmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY)));
+                        try {
+                            if(orb.ID.equals(Frost.ORB_ID) || orb.ID.equals(Plasma.ORB_ID) || (Aspiration.hasConspire && orb.ID.equals(Water.ORB_ID)) || (Aspiration.hasReplay && (orb.ID.equals(ManaSparkOrb.ORB_ID) || orb.ID.equals(CrystalOrb.ORB_ID)))) {
+                                AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration));
+                            } else if(orb.ID.equals(Dark.ORB_ID)) {
+                                AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration, Color.PURPLE));
+                            } else if(orb.ID.equals(Lightning.ORB_ID) || (Aspiration.hasReplay && orb.ID.equals(ReplayLightOrb.ORB_ID))) {
+                                AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration, Color.YELLOW));
+                            } else if (Aspiration.hasReplay && orb.ID.equals(HellFireOrb.ORB_ID)) {
+                                AbstractDungeon.effectList.add(new BetterSmallLaserEffect(AbstractDungeon.player.orbs.get(0).cX, AbstractDungeon.player.orbs.get(0).cY, o.cX, o.cY, duration, Color.RED));
+                            }
+                        } catch (Exception e) {
+                            Aspiration.logger.info(e);
+                        }
+                    }
+                }
+            });
+        }
 
         this.isDone = true;
     }

--- a/src/main/java/aspiration/actions/ReplaceOrbAction.java
+++ b/src/main/java/aspiration/actions/ReplaceOrbAction.java
@@ -1,0 +1,34 @@
+package aspiration.actions;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.orbs.AbstractOrb;
+
+public class ReplaceOrbAction extends AbstractGameAction {
+    private AbstractOrb toReplace;
+    private AbstractOrb newOrb;
+
+    public ReplaceOrbAction(AbstractOrb toReplace, AbstractOrb newOrb)
+    {
+        this.toReplace = toReplace;
+        this.newOrb = newOrb;
+    }
+
+    @Override
+    public void update() {
+        if (AbstractDungeon.player.orbs.contains(toReplace))
+        {
+            int index = AbstractDungeon.player.orbs.indexOf(toReplace);
+            newOrb.cX = newOrb.tX = toReplace.cX;
+            newOrb.cY = newOrb.tY = toReplace.cY;
+            newOrb.hb.move(newOrb.cX, newOrb.cY);
+            AbstractDungeon.player.orbs.set(index, newOrb);
+
+            AbstractDungeon.actionManager.orbsChanneledThisCombat.add(newOrb);
+            AbstractDungeon.actionManager.orbsChanneledThisTurn.add(newOrb);
+
+            newOrb.applyFocus();
+        }
+        this.isDone = true;
+    }
+}

--- a/src/main/java/aspiration/actions/unique/FaultyCouplerAction.java
+++ b/src/main/java/aspiration/actions/unique/FaultyCouplerAction.java
@@ -1,0 +1,51 @@
+package aspiration.actions.unique;
+
+import aspiration.actions.RemoveSpecificOrbAction;
+import aspiration.actions.ReplaceOrbAction;
+import aspiration.orbs.AmalgamateOrb;
+import aspiration.orbs.OrbUtilityMethods;
+import aspiration.relics.uncommon.FaultyCoupler;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.defect.ChannelAction;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.orbs.AbstractOrb;
+import com.megacrit.cardcrawl.orbs.EmptyOrbSlot;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static aspiration.relics.uncommon.FaultyCoupler.AMA_CHANCE;
+
+public class FaultyCouplerAction extends AbstractGameAction {
+
+    private AbstractOrb channeled;
+
+    public FaultyCouplerAction(AbstractOrb channeled)
+    {
+        this.channeled = channeled;
+    }
+
+    @Override
+    public void update() {
+        if (OrbUtilityMethods.isValidAmalgamateComponent(channeled) && AbstractDungeon.player.orbs.contains(channeled)) {
+            if (AbstractDungeon.cardRandomRng.random(99) <= AMA_CHANCE) {
+                if (AbstractDungeon.player.hasRelic(FaultyCoupler.ID))
+                {
+                    AbstractDungeon.player.getRelic(FaultyCoupler.ID).flash();
+                }
+
+                ArrayList<AbstractOrb> orbs = new ArrayList<>();
+                for (AbstractOrb o : AbstractDungeon.player.orbs) {
+                    if (o != null && !EmptyOrbSlot.ORB_ID.equals(o.ID)) {
+                        if (OrbUtilityMethods.isValidAmalgamateComponent(o)) {
+                            orbs.add(o);
+                        }
+                    }
+                }
+                AbstractDungeon.actionManager.addToTop(new ReplaceOrbAction(channeled, new AmalgamateOrb(new ArrayList<>(Arrays.asList(channeled, orbs.get(AbstractDungeon.cardRandomRng.random(orbs.size() - 1)))))));
+            }
+        }
+
+        this.isDone = true;
+    }
+}

--- a/src/main/java/aspiration/relics/boss/Stellarator.java
+++ b/src/main/java/aspiration/relics/boss/Stellarator.java
@@ -2,9 +2,11 @@ package aspiration.relics.boss;
 
 import aspiration.actions.FuseValidOrbsAction;
 import aspiration.relics.abstracts.AspirationRelic;
+import aspiration.relics.skillbooks.DefectSkillbook;
 import com.evacipated.cardcrawl.mod.stslib.relics.OnChannelRelic;
 import com.megacrit.cardcrawl.actions.defect.AnimateOrbAction;
 import com.megacrit.cardcrawl.actions.defect.EvokeOrbAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.orbs.AbstractOrb;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
@@ -30,6 +32,11 @@ public class Stellarator extends AspirationRelic implements OnChannelRelic {
             AbstractDungeon.actionManager.addToTop(new EvokeOrbAction(1));
             AbstractDungeon.actionManager.addToTop(new AnimateOrbAction(1));
         }
+    }
+
+    @Override
+    public boolean canSpawn() {
+        return (AbstractDungeon.player.chosenClass == AbstractPlayer.PlayerClass.DEFECT || AbstractDungeon.player.hasRelic(DefectSkillbook.ID));
     }
 
     public AbstractRelic makeCopy() {

--- a/src/main/java/aspiration/relics/uncommon/FaultyCoupler.java
+++ b/src/main/java/aspiration/relics/uncommon/FaultyCoupler.java
@@ -1,25 +1,18 @@
 package aspiration.relics.uncommon;
 
-import aspiration.actions.RemoveSpecificOrbAction;
+import aspiration.actions.unique.FaultyCouplerAction;
 import aspiration.orbs.AmalgamateOrb;
-import aspiration.orbs.OrbUtilityMethods;
 import aspiration.relics.abstracts.AspirationRelic;
 import aspiration.relics.skillbooks.DefectSkillbook;
 import com.evacipated.cardcrawl.mod.stslib.relics.OnChannelRelic;
-import com.megacrit.cardcrawl.actions.defect.ChannelAction;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.orbs.AbstractOrb;
-import com.megacrit.cardcrawl.orbs.EmptyOrbSlot;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 public class FaultyCoupler extends AspirationRelic implements OnChannelRelic {
     public static final String ID = "aspiration:FaultyCoupler";
-
-    private static final int AMA_CHANCE = 20;
+    public static final int AMA_CHANCE = 20;
 
     public FaultyCoupler() {
         super(ID, "FaultyCoupler.png", RelicTier.UNCOMMON, LandingSound.CLINK);
@@ -33,20 +26,7 @@ public class FaultyCoupler extends AspirationRelic implements OnChannelRelic {
     @Override
     public void onChannel(AbstractOrb orbyBoi) {
         if(AbstractDungeon.player.filledOrbCount() > 1 && !orbyBoi.ID.equals(AmalgamateOrb.ORB_ID)) {
-            if(OrbUtilityMethods.isValidAmalgamateComponent(orbyBoi)) {
-                if (AbstractDungeon.cardRandomRng.random(99) < AMA_CHANCE) {
-                    ArrayList<AbstractOrb> orbs = new ArrayList<>();
-                    for (AbstractOrb o : AbstractDungeon.player.orbs) {
-                        if (o != null && !EmptyOrbSlot.ORB_ID.equals(o.ID)) {
-                            if (OrbUtilityMethods.isValidAmalgamateComponent(o)) {
-                                orbs.add(o);
-                            }
-                        }
-                    }
-                    AbstractDungeon.actionManager.addToTop(new ChannelAction(new AmalgamateOrb(new ArrayList<>(Arrays.asList(orbyBoi, orbs.get(AbstractDungeon.cardRandomRng.random(orbs.size() - 1)))))));
-                    AbstractDungeon.actionManager.addToTop(new RemoveSpecificOrbAction(orbyBoi));
-                }
-            }
+            AbstractDungeon.actionManager.addToTop(new FaultyCouplerAction(orbyBoi));
         }
     }
 


### PR DESCRIPTION
Note - Should Stellarator spawn condition be changed to also be able to spawn if player has Defect Skillbook? I changed canSpawn, but it won't matter unless the relic adding is also changed.

The errors occured because if Fault Coupler triggered after Stellarator, it's actions would occur first (because of add to top) which results in removing an orb and then channeling an amalgamate, which results in Stellarator being triggered a second time. This results in entirely too many attempts at evoking and amalgamation.

Faulty Coupler is changed to simply replace the orb.

One other change that I haven't made that could be nice - Make Stellarator flash when triggered